### PR TITLE
Remove devtools dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,4 @@ Imports:
     tibble,
     rlang,
     utils
-RoxygenNote: 6.1.1
+RoxygenNote: 6.1.99.9001

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,9 +9,8 @@ Depends: R (>= 3.5.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-Imports: 
+Imports:
     fs,
-    devtools,
     readr,
     stringr,
     purrr,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,6 @@
 
 export(cpp_decorations)
 export(cpp_files)
-import(devtools)
 import(fs)
 import(readr)
 import(rlang)

--- a/R/decor.R
+++ b/R/decor.R
@@ -1,12 +1,10 @@
 #' C++ files from a package
 #'
-#' @param pkg See [devtools::as.package()]
+#' @param pkg See `devtools::as.package()`
 #'
 #' @export
 cpp_files <- function(pkg = ".") {
-  pkg <- as.package(pkg)
-
-  src <- path(pkg$path, "src")
+  src <- path(pkg, "src")
   if (dir_exists(src)) {
     dir_ls(src, regexp = "[.](cc|cpp)$")
   } else {
@@ -17,7 +15,7 @@ cpp_files <- function(pkg = ".") {
 
 #' Decorations in a C++ file
 #'
-#' @param pkg A package, see [devtools::as.package()]
+#' @param pkg A package, see `devtools::as.package()`
 #' @param files C++ files
 #'
 #' @export

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,4 @@
 #' @useDynLib decor, .registration = TRUE
-#' @import devtools
 #' @import fs
 #' @import rlang
 #' @import stringr

--- a/man/cpp_decorations.Rd
+++ b/man/cpp_decorations.Rd
@@ -7,7 +7,7 @@
 cpp_decorations(pkg = ".", files = cpp_files(pkg = pkg))
 }
 \arguments{
-\item{pkg}{A package, see [devtools::as.package()]}
+\item{pkg}{A package, see `devtools::as.package()`}
 
 \item{files}{C++ files}
 }

--- a/man/cpp_files.Rd
+++ b/man/cpp_files.Rd
@@ -7,7 +7,7 @@
 cpp_files(pkg = ".")
 }
 \arguments{
-\item{pkg}{See [devtools::as.package()]}
+\item{pkg}{See `devtools::as.package()`}
 }
 \description{
 C++ files from a package


### PR DESCRIPTION
This was causing about 40+ extra packages to be installed along with decor on arrow's CI. `devtools` was only used for `as.package`, which for `decor` basically just gives you some better error messages if you provide a bad path. Doesn't seem worth it IMO. 