### PR TITLE
Fix ref/deref operator whitespace as pointed out in #6

### DIFF
--- a/src/parse_cpp_function.cpp
+++ b/src/parse_cpp_function.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 static const char* const kWhitespaceChars = " \f\n\r\t\v";
+static const char* const kWhiteDeRefChars = " \f\n\r\t\v*&";
 
 void set_rownames(SEXP x, int n) {
   SEXP rownames = PROTECT(Rf_allocVector(INTSXP, 2));
@@ -112,13 +113,17 @@ SEXP parse_arguments(const std::string& args) {
     }
 
     // where does the type end
-    end = arg.find_last_of(kWhitespaceChars);
+    end = arg.find_last_of(kWhiteDeRefChars);
 
     // name
     SET_STRING_ELT(name, i, Rf_mkCharLen(arg.data() + end + 1, arg.size() - end - 1));
 
     // type
-    SET_STRING_ELT(type, i, Rf_mkCharLen(arg.data(), end));
+    if (end == arg.find_last_of(kWhitespaceChars)) {
+      SET_STRING_ELT(type, i, Rf_mkCharLen(arg.data(), end));
+    } else {
+      SET_STRING_ELT(type, i, Rf_mkCharLen(arg.data(), end + 1));
+    }
   }
 
   SEXP tbl_args = PROTECT(Rf_allocVector(VECSXP, 3));

--- a/tests/testthat/test-decor.R
+++ b/tests/testthat/test-decor.R
@@ -407,6 +407,36 @@ describe("parse_cpp_function", {
         )
       )
     )
+
+    expect_equal(
+      parse_cpp_function(c("double foo(int bar, const char *baz)", "{", "}")),
+      tibble(
+        name = "foo",
+        return_type = "double",
+        args = list(
+          tibble(
+            type = c("int", "const char *"),
+            name = c("bar", "baz"),
+            default = c(NA_character_, NA_character_)
+          )
+        )
+      )
+    )
+
+    expect_equal(
+      parse_cpp_function(c("double foo(int bar, int**baz)", "{", "}")),
+      tibble(
+        name = "foo",
+        return_type = "double",
+        args = list(
+          tibble(
+            type = c("int", "int**"),
+            name = c("bar", "baz"),
+            default = c(NA_character_, NA_character_)
+          )
+        )
+      )
+    )
   })
 
   it("works with functions with default arguments", {
@@ -418,6 +448,21 @@ describe("parse_cpp_function", {
         args = list(
           tibble(
             type = c("int", "const char*"),
+            name = c("bar", "baz"),
+            default = c("1", '"hi"')
+          )
+        )
+      )
+    )
+
+    expect_equal(
+      parse_cpp_function(c("double foo(int bar = 1, const char *baz = \"hi\")", "{", "}")),
+      tibble(
+        name = "foo",
+        return_type = "double",
+        args = list(
+          tibble(
+            type = c("int", "const char *"),
             name = c("bar", "baz"),
             default = c("1", '"hi"')
           )
@@ -443,6 +488,21 @@ describe("parse_cpp_function", {
     )
 
     expect_equal(
+      parse_cpp_function(c("foo::bar foo(const char[] bar, const std::string &baz = \"hi\")", "{", "}")),
+      tibble(
+        name = "foo",
+        return_type = "foo::bar",
+        args = list(
+          tibble(
+            type = c("const char[]", "const std::string &"),
+            name = c("bar", "baz"),
+            default = c(NA_character_, '"hi"')
+          )
+        )
+      )
+    )
+
+    expect_equal(
       parse_cpp_function(c("foo::bar foo(std::vector<int>& bar, int baz = foo2())", "{", "}")),
       tibble(
         name = "foo",
@@ -450,6 +510,21 @@ describe("parse_cpp_function", {
         args = list(
           tibble(
             type = c("std::vector<int>&", "int"),
+            name = c("bar", "baz"),
+            default = c(NA_character_, 'foo2()')
+          )
+        )
+      )
+    )
+
+    expect_equal(
+      parse_cpp_function(c("foo::bar foo(std::vector<int> &bar, int baz = foo2())", "{", "}")),
+      tibble(
+        name = "foo",
+        return_type = "foo::bar",
+        args = list(
+          tibble(
+            type = c("std::vector<int> &", "int"),
             name = c("bar", "baz"),
             default = c(NA_character_, 'foo2()')
           )
@@ -467,6 +542,21 @@ describe("parse_cpp_function", {
         args = list(
           tibble(
             type = c("int", "const char*"),
+            name = c("bar", "baz"),
+            default = c("1", '"hi"')
+          )
+        )
+      )
+    )
+
+    expect_equal(
+      parse_cpp_function(c("double foo(int bar = 1, const char *baz = \"hi\");")),
+      tibble(
+        name = "foo",
+        return_type = "double",
+        args = list(
+          tibble(
+            type = c("int", "const char *"),
             name = c("bar", "baz"),
             default = c("1", '"hi"')
           )


### PR DESCRIPTION
I recently ran into the situation where clang-format was configured to have whitespace *before* reference/dereference operators, causing me the issue described in #6. As there hasn't been much movement since then, I went ahead and prepared a small PR. Happy to make changes if requested.