### PR TITLE
internal parse_cpp_function() gains a way to bubble up an error. Used…

### DIFF
--- a/R/decor.R
+++ b/R/decor.R
@@ -163,5 +163,10 @@ parse_cpp_function <- function(context, is_attribute = FALSE) {
   # If not a first brace assume it is just a declaration.
   signature <- sub("[[:space:]]*[{].*$", "", paste(context[seq(1L, first_brace_or_statement)], collapse = " "))
 
-  .Call(decor_parse_cpp_function, signature)
+  out <- .Call(decor_parse_cpp_function, signature)
+
+  if (is.character(out))
+    stop(out)
+
+  out
 }

--- a/tests/testthat/test-decor.R
+++ b/tests/testthat/test-decor.R
@@ -432,6 +432,11 @@ describe("parse_cpp_function", {
       )
     )
 
+    expect_error(
+      parse_cpp_function("raws C_encode(int x, strings) { }"),
+      "has no type"
+    )
+
     expect_equal(
       parse_cpp_function(c("double foo(int bar, const char *baz)", "{", "}")),
       tibble(


### PR DESCRIPTION
… for when an argument has no type, as in #5