### PR TITLE
`parse_cpp_function()` strips `//` comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 * `parse_cpp_function()` supports spaces before the argument list (#4) and handles ref/deref (#6, @nbenn).
 
+* `parse_cpp_function()` strips `//` comments (#8).
+
 # decor 1.0.1
 
 * Romain François is now the maintainer.

--- a/R/decor.R
+++ b/R/decor.R
@@ -160,8 +160,11 @@ parse_cpp_function <- function(context, is_attribute = FALSE) {
 
   first_brace_or_statement <- grep("[{;]", context)[[1L]]
 
+  # remove // comments from context
+  context <- sub("//.*", "", context[seq(1L, first_brace_or_statement)])
+
   # If not a first brace assume it is just a declaration.
-  signature <- sub("[[:space:]]*[{].*$", "", paste(context[seq(1L, first_brace_or_statement)], collapse = " "))
+  signature <- sub("[[:space:]]*[{].*$", "", paste(context, collapse = " "))
 
   out <- .Call(decor_parse_cpp_function, signature)
 

--- a/tests/testthat/test-decor.R
+++ b/tests/testthat/test-decor.R
@@ -386,6 +386,23 @@ describe("parse_cpp_function", {
     )
   })
 
+  it("works with inline // comments for arguments", {
+    expect_equal(
+      parse_cpp_function(c('int foo(int a, // = 5', 'int b) {', 'return 0;', '}')),
+      tibble(
+        name = "foo",
+        return_type = "int",
+        args = list(
+          tibble(
+            type = c("int", "int"),
+            name = c("a", "b"),
+            default = c(NA_character_, NA_character_)
+          )
+        )
+      )
+    )
+  })
+
   it("works with functions taking arguments", {
     expect_equal(
       parse_cpp_function(c("double foo(int bar)", "{", "}")),


### PR DESCRIPTION
closes #8